### PR TITLE
Fix issue with index out of range upon install

### DIFF
--- a/lib/atom-nyancat.coffee
+++ b/lib/atom-nyancat.coffee
@@ -46,8 +46,8 @@ module.exports = AtomNyancat =
     editor = atom.workspace.getActiveTextEditor()
     @view.clear()
     if editor?
-      lastVisibleRow = editor.getVisibleRowRange()[1]
-      lastScreenLine = editor.getScreenLineCount()
+      lastVisibleRow = editor.firstVisibleScreenRow
+      lastScreenLine = editor.getLineCount() - editor.rowsPerPage
       percent = lastVisibleRow/parseFloat(lastScreenLine)
     else
       precent = 1


### PR DESCRIPTION
This appears to fix the issue when installing.. accessed the line numbers through different methods and properties

Address #2, #1 
